### PR TITLE
Ival

### DIFF
--- a/R/fisher.R
+++ b/R/fisher.R
@@ -68,8 +68,8 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
         for (j in 1:w_size) {
           if (!(j %in% Bin_2)) {
             binj <- Bin[j,]
-            # note: the last test is redundant since IVAL = -Inf
-            Bin_1_temp <- c(j, which(!(i_vals %in% Bin_2) & (binj >= tl1) & (binj != IVAL)))
+            # note: since IVAL is -Inf, the test for IVAL is now always TRUE and was removed
+            Bin_1_temp <- c(j, which(!(i_vals %in% Bin_2) & (binj >= tl1)))
             Bin_1 = c(Bin_1, list(Bin_1_temp))
             Bin_2 = c(Bin_2, Bin_1_temp)
           }

--- a/R/fisher.R
+++ b/R/fisher.R
@@ -38,10 +38,8 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
   k_init = c()
   window_seq = seq(1, nrow(df), w_incre)
   number_of_states_per_tl = matrix(ncol = 100, nrow = length(window_seq) - (w_size / w_incre - 1))
-  rownames(number_of_states_per_tl) = paste0("wi", window_seq[1:nrow(number_of_states_per_tl)])
-  colnames(number_of_states_per_tl) = paste0("tl", 1:100)
   for (i in window_seq) {
-    window_index_str = paste0("wi", as.character(i))
+    window_index = i
     Data_win = as.matrix(na.omit(df[i:(i+w_size - 1),2:ncol(df)]), byrow = TRUE)
     if (nrow(Data_win) == w_size) {
       Bin = c()
@@ -77,7 +75,7 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
           }
         }
 
-        number_of_states_per_tl[window_index_str, tl] = length(Bin_1)
+        number_of_states_per_tl[window_index, tl] <- length(Bin_1)
 
         prob = c(0, lengths(Bin_1) / length(Bin_2), 0)
         prob_q = sqrt(prob)
@@ -98,12 +96,16 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
   if (length(k_init) == 0) {
     k_init = c(1)
   }
-  number_of_states_per_tl <- number_of_states_per_tl[rowSums(is.na(number_of_states_per_tl)) != ncol(number_of_states_per_tl), ]
-  FI_means = rowMeans(FI_final[,min(k_init):ncol(FI_final)])
+
+  ncNST <- ncol(number_of_states_per_tl)
+  minKInit <- min(k_init)
+  subNST <- number_of_states_per_tl[, minKInit:ncNST]
+  number_of_states_per_tl <- number_of_states_per_tl[rowSums(is.na(number_of_states_per_tl)) != ncNST, ]
+  FI_means = rowMeans(FI_final[,minKInit:ncol(FI_final)])
   time_windows = df[1:nrow(FI_final) * w_incre + w_size - 1, 1]
-  mean_no_states = rowMeans(number_of_states_per_tl[,min(k_init):ncol(number_of_states_per_tl)]) # function needs to be checked
-  median_no_states = matrixStats::rowMedians(number_of_states_per_tl[,min(k_init):ncol(number_of_states_per_tl)]) # function needs to be checked
-  sum_of_states = rowSums(number_of_states_per_tl[,min(k_init):ncol(number_of_states_per_tl)]) # function needs to be checked
+  mean_no_states = rowMeans(subNST) # function needs to be checked
+  median_no_states = matrixStats::rowMedians(subNST) # function needs to be checked
+  sum_of_states = rowSums(subNST) # function needs to be checked
 
 
   FI_smth = c()

--- a/R/fisher.R
+++ b/R/fisher.R
@@ -40,7 +40,7 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
   colnames(number_of_states_per_tl) = paste0("tl", 1:100)
   for (i in window_seq) {
     window_index_str = paste0("wi", as.character(i))
-    Data_win = na.omit(df[i:(i+w_size - 1),2:ncol(df)])
+    Data_win = as.matrix(na.omit(df[i:(i+w_size - 1),2:ncol(df)]))
     if (nrow(Data_win) == w_size) {
       Bin = c()
       for (m in 1:w_size) {
@@ -136,6 +136,7 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
   lines(df_FI$time_windows, df_FI$FI_smth, type="l", col="red")
   }
   print(sprintf("Completed in %.2f seconds", as.numeric(Sys.time()) - start_time))
+  print(sprintf("Checksum: %.10f", sum(df_FI)))
   #list(df = df_FI, number_of_states_per_tl = number_of_states_per_tl)
   df_FI
 }

--- a/R/fisher.R
+++ b/R/fisher.R
@@ -77,8 +77,7 @@ fisher = function(df, sos = c(), w_size = 8, w_incre = 1, smooth_step = 3, RedRu
           }
         }
 
-        s_tl <- paste0("tl", tl)
-        number_of_states_per_tl[window_index_str, s_tl] = length(Bin_1)
+        number_of_states_per_tl[window_index_str, tl] = length(Bin_1)
 
         prob = c(0, lengths(Bin_1) / length(Bin_2), 0)
         prob_q = sqrt(prob)


### PR DESCRIPTION
Hi @QuinnAsena 

Below are the list of improvements (in bold the more significant). You should expect a speedup of 5-10x, depending on the size of the data frame.

The check sums haven't changed but the best would be to create a unit test to check that the below changes are OK. I'm not exactly sure what to expect from the output so another look from you would be needed. 

Create Data_win by row (small improvement)
**Instead of assigning “I” to some Bin_temp values, assign -Inf. This allows us to keep all elements as numerical values (no casting required). Saves a lot.**
Vectorised the Bin_temp_1 line (should help for the bigger cases, need to check)
**Vectorised the Bin_1_temp line. Instead of the if statement we now use the which function. Note that there is no need to test Bin[j,i] != "I" since this condition will automatically be satisfied with Bin[j,i]) >= tl1 when choosing “I” to be -Inf. Big impact.**
Compute once and reuse. Small impact. 
**Replaced indexing of matrix by col/rtow string with direct indexing. Big impact.**  
